### PR TITLE
Implement auth, content generation, and posting routers

### DIFF
--- a/autopost_backend/main.py
+++ b/autopost_backend/main.py
@@ -1,6 +1,12 @@
 from fastapi import FastAPI
+
+from .routers import register as register_routers
+
 app = FastAPI()
 
+register_routers(app)
+
+
 @app.get("/")
-def root():
+def root() -> dict:
     return {"message": "AutoPost Backend is running"}

--- a/autopost_backend/routers/__init__.py
+++ b/autopost_backend/routers/__init__.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+from . import auth, content, posting
+
+
+def register(app: FastAPI) -> None:
+    app.include_router(auth.router)
+    app.include_router(content.router)
+    app.include_router(posting.router)

--- a/autopost_backend/routers/auth.py
+++ b/autopost_backend/routers/auth.py
@@ -1,0 +1,51 @@
+from fastapi import APIRouter, HTTPException
+import os
+import requests
+from requests.auth import HTTPBasicAuth
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+@router.get("/facebook")
+def facebook_token() -> dict:
+    app_id = os.getenv("FB_APP_ID")
+    app_secret = os.getenv("FB_APP_SECRET")
+    if not app_id or not app_secret:
+        raise HTTPException(status_code=500, detail="Facebook credentials not configured")
+    params = {
+        "client_id": app_id,
+        "client_secret": app_secret,
+        "grant_type": "client_credentials",
+    }
+    resp = requests.get("https://graph.facebook.com/oauth/access_token", params=params)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return resp.json()
+
+@router.get("/twitter")
+def twitter_token() -> dict:
+    api_key = os.getenv("TW_API_KEY")
+    api_secret = os.getenv("TW_API_SECRET")
+    if not api_key or not api_secret:
+        raise HTTPException(status_code=500, detail="Twitter credentials not configured")
+    data = {"grant_type": "client_credentials"}
+    auth = HTTPBasicAuth(api_key, api_secret)
+    resp = requests.post("https://api.twitter.com/oauth2/token", data=data, auth=auth)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return resp.json()
+
+@router.get("/tiktok")
+def tiktok_token() -> dict:
+    client_key = os.getenv("TIKTOK_CLIENT_KEY")
+    client_secret = os.getenv("TIKTOK_CLIENT_SECRET")
+    if not client_key or not client_secret:
+        raise HTTPException(status_code=500, detail="TikTok credentials not configured")
+    data = {
+        "client_key": client_key,
+        "client_secret": client_secret,
+        "grant_type": "client_credential"
+    }
+    resp = requests.post("https://open-api.tiktok.com/oauth/access_token", data=data)
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return resp.json()

--- a/autopost_backend/routers/content.py
+++ b/autopost_backend/routers/content.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+import openai
+import os
+
+router = APIRouter(prefix="/content", tags=["content"])
+
+class Prompt(BaseModel):
+    prompt: str
+
+@router.post("/generate")
+def generate_content(data: Prompt) -> dict:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="OPENAI_API_KEY not configured")
+    openai.api_key = api_key
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": data.prompt}]
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"content": resp.choices[0].message.content}

--- a/autopost_backend/routers/posting.py
+++ b/autopost_backend/routers/posting.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+import os
+import requests
+
+router = APIRouter(prefix="/post", tags=["post"])
+
+class PostRequest(BaseModel):
+    content: str
+    platforms: list[str]
+
+@router.post("")
+def post_content(req: PostRequest) -> dict:
+    results = {}
+    for platform in req.platforms:
+        name = platform.lower()
+        if name == "facebook":
+            results[name] = post_facebook(req.content)
+        elif name == "twitter":
+            results[name] = post_twitter(req.content)
+        elif name == "tiktok":
+            results[name] = post_tiktok(req.content)
+        else:
+            results[name] = {"error": "unsupported platform"}
+    return results
+
+def post_facebook(message: str) -> dict:
+    token = os.getenv("FB_ACCESS_TOKEN")
+    page_id = os.getenv("FB_PAGE_ID")
+    if not token or not page_id:
+        return {"error": "Facebook credentials missing"}
+    resp = requests.post(
+        f"https://graph.facebook.com/{page_id}/feed",
+        params={"message": message, "access_token": token},
+    )
+    try:
+        return resp.json()
+    except Exception:
+        return {"status": resp.status_code}
+
+def post_twitter(message: str) -> dict:
+    token = os.getenv("TWITTER_ACCESS_TOKEN")
+    secret = os.getenv("TWITTER_ACCESS_SECRET")
+    bearer = os.getenv("TW_BEARER_TOKEN")
+    if not token or not secret or not bearer:
+        return {"error": "Twitter credentials missing"}
+    headers = {"Authorization": f"Bearer {bearer}"}
+    data = {"text": message}
+    resp = requests.post("https://api.twitter.com/2/tweets", json=data, headers=headers)
+    try:
+        return resp.json()
+    except Exception:
+        return {"status": resp.status_code}
+
+def post_tiktok(message: str) -> dict:
+    token = os.getenv("TIKTOK_ACCESS_TOKEN")
+    if not token:
+        return {"error": "TikTok token missing"}
+    data = {"text": message, "access_token": token}
+    resp = requests.post("https://open-api.tiktok.com/share/video", data=data)
+    try:
+        return resp.json()
+    except Exception:
+        return {"status": resp.status_code}


### PR DESCRIPTION
## Summary
- add router registration to the FastAPI app
- implement endpoints for automatic token retrieval for Facebook, Twitter, and TikTok
- implement content generation using OpenAI API
- implement multi-platform posting to Facebook, Twitter, and TikTok

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e82d4060c832693d5a18cf0536b7d